### PR TITLE
#30 devcontainer の Claude Code を npm から native インストーラへ切り替え

### DIFF
--- a/.devcontainer/go/devcontainer.json
+++ b/.devcontainer/go/devcontainer.json
@@ -7,8 +7,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"
-    },
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+    }
   },
   "customizations": {
     "vscode": {
@@ -46,7 +45,7 @@
     "gh-extensions-install": "echo '=== gh extensions install ===' && gh extension install yahsan2/gh-sub-issue",
     "go-version": "echo '=== Go ===' && go version",
     "gh-version": "echo '=== GitHub CLI ===' && gh --version",
-    "claude-version": "echo '=== Claude Code ===' && claude --version",
+    "claude-code": "echo '=== Claude Code (native install) ===' && curl -fsSL https://claude.ai/install.sh | bash && \"$HOME/.local/bin/claude\" --version",
     "message": "echo 'Go の開発コンテナが起動し、セットアップを実行中...'"
   },
   "forwardPorts": [

--- a/.devcontainer/nextjs/devcontainer-lock.json
+++ b/.devcontainer/nextjs/devcontainer-lock.json
@@ -1,10 +1,5 @@
 {
   "features": {
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {
-      "version": "1.0.5",
-      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
-      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
-    },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",

--- a/.devcontainer/nextjs/devcontainer.json
+++ b/.devcontainer/nextjs/devcontainer.json
@@ -4,8 +4,7 @@
   "service": "nextjs-workspace-devcontainer",
   "workspaceFolder": "/monorepo-root-as-nextjs-workspace",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {
     "vscode": {
@@ -39,7 +38,7 @@
     "node-version": "echo '=== Node.js ===' && node --version",
     "npm-version": "echo '=== npm ===' && npm --version",
     "gh-version": "echo '=== GitHub CLI ===' && gh --version",
-    "claude-version": "echo '=== Claude Code ===' && claude --version",
+    "claude-code": "echo '=== Claude Code (native install) ===' && curl -fsSL https://claude.ai/install.sh | bash && \"$HOME/.local/bin/claude\" --version",
     "message": "echo 'Next.js の開発コンテナが起動し、セットアップを実行中...'"
   },
   "forwardPorts": [

--- a/.devcontainer/python/devcontainer.json
+++ b/.devcontainer/python/devcontainer.json
@@ -7,8 +7,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"
-    },
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+    }
   },
   "customizations": {
     "vscode": {
@@ -48,7 +47,7 @@
     "uv-version": "echo '=== uv ===' && uv --version",
     "python-version": "echo '=== Python ===' && python --version",
     "gh-version": "echo '=== GitHub CLI ===' && gh --version",
-    "claude-version": "echo '=== Claude Code ===' && claude --version",
+    "claude-code": "echo '=== Claude Code (native install) ===' && curl -fsSL https://claude.ai/install.sh | bash && \"$HOME/.local/bin/claude\" --version",
     "message": "echo 'Python の開発コンテナが起動し、セットアップを実行中...'"
   },
   "forwardPorts": [

--- a/.devcontainer/terraform/devcontainer.json
+++ b/.devcontainer/terraform/devcontainer.json
@@ -42,15 +42,14 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"
-    },
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+    }
   },
   "postCreateCommand": {
     "npm-install": "echo '=== npm install ===' && npm install",
     "gh-extensions-install": "echo '=== gh extensions install ===' && gh extension install yahsan2/gh-sub-issue",
     "terraform-version": "echo '=== Terraform ===' && terraform --version",
     "gh-version": "echo '=== GitHub CLI ===' && gh --version",
-    "claude-version": "echo '=== Claude Code ===' && claude --version",
+    "claude-code": "echo '=== Claude Code (native install) ===' && curl -fsSL https://claude.ai/install.sh | bash && \"$HOME/.local/bin/claude\" --version",
     "message": "echo 'Terraform の開発コンテナが起動し、セットアップを実行中...'"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📋 変更内容

### 📄 概要

devcontainer の Claude Code 導入を、npm グローバル(`ghcr.io/anthropics/devcontainer-features/claude-code`)から **native インストーラ方式**へ切り替えた。

npm 方式は feature がビルド時に **root** で `npm install -g` するため、パッケージが root 所有になり、実行ユーザー `vscode` が自動アップデート時に上書きできず `no write permission to npm prefix` で失敗していた。native インストーラはユーザーホーム(`~/.local/bin`)へ導入するため実行ユーザー所有となり、この権限問題がクラスごと解消する(得られるバイナリは npm 版と同一)。

### 📂 変更ファイル

- `.devcontainer/go/devcontainer.json` - claude-code feature 削除、postCreateCommand を native 導入に置換
- `.devcontainer/python/devcontainer.json` - 同上
- `.devcontainer/terraform/devcontainer.json` - 同上
- `.devcontainer/nextjs/devcontainer.json` - claude-code feature 削除、postCreateCommand を native 導入に置換
- `.devcontainer/nextjs/devcontainer-lock.json` - 不要になった claude-code エントリを削除

置換後の postCreateCommand:
`curl -fsSL https://claude.ai/install.sh | bash && "$HOME/.local/bin/claude" --version`
（postCreateCommand は並列実行のため install と確認を `&&` で1コマンドに束ね順序を保証。確認はフルパスで実行）

### ➕ Issue 外の変更

無し

## ✅ 完了条件 (Issue に記載された内容)

- [x] 4コンテナ(go/python/terraform/nextjs)から claude-code feature を削除
- [x] postCreateCommand を native 導入+確認に置換(並列実行対策として `&&` で束ねる)
- [x] node feature はリポジトリの `npm install` に必要なため維持
- [x] 各 base image に `curl` が存在することを確認(追加導入不要)
- [x] nextjs の devcontainer-lock.json から不要な claude-code エントリを削除

## 🏷️ タスク種別 (Issue に記載された内容)

- [ ] 🖥️ フロントエンド開発
- [ ] ⚙️ バックエンド開発
- [ ] 🏗️ インフラ構築
- [ ] 📝 ドキュメント作成
- [x] 🔧 設定
- [ ] ❓ その他

## 🖼️ スクリーンショット（UI 変更がある場合のみ）

無し

## 🔗 対応する Issue

Closes #30

## 💬 備考

- 反映は devcontainer のリビルド時。既存の稼働中コンテナは npm 版のままのため、切り替え確認にはリビルドが必要。
- `~/.local/bin` は `.profile` により既に PATH 済み。